### PR TITLE
Add ja and it localization

### DIFF
--- a/features/shopping_cart/l10n.yaml
+++ b/features/shopping_cart/l10n.yaml
@@ -1,4 +1,4 @@
-preferred-supported-locales: [en, fa]
+preferred-supported-locales: [en, fa, ja, it]
 synthetic-package: false
 output-dir: ./lib/src/l10n/generated
 arb-dir: ./lib/src/l10n

--- a/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations.dart
+++ b/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -8,15 +7,17 @@ import 'package:intl/intl.dart' as intl;
 
 import 'shopping_cart_localizations_en.dart';
 import 'shopping_cart_localizations_fa.dart';
+import 'shopping_cart_localizations_it.dart';
+import 'shopping_cart_localizations_ja.dart';
 
-/// Callers can lookup localized strings with an instance of ShoppingCartLocalizations returned
-/// by `ShoppingCartLocalizations.of(context)`.
+/// Callers can lookup localized strings with an instance of ShoppingCartLocalizations
+/// returned by `ShoppingCartLocalizations.of(context)`.
 ///
 /// Applications need to include `ShoppingCartLocalizations.delegate()` in their app's
-/// localizationDelegates list, and the locales they support in the app's
-/// supportedLocales list. For example:
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
 ///
-/// ```
+/// ```dart
 /// import 'generated/shopping_cart_localizations.dart';
 ///
 /// return MaterialApp(
@@ -31,14 +32,14 @@ import 'shopping_cart_localizations_fa.dart';
 /// Please make sure to update your pubspec.yaml to include the following
 /// packages:
 ///
-/// ```
+/// ```yaml
 /// dependencies:
 ///   # Internationalization support.
 ///   flutter_localizations:
 ///     sdk: flutter
 ///   intl: any # Use the pinned version from flutter_localizations
 ///
-///   # rest of dependencies
+///   # Rest of dependencies
 /// ```
 ///
 /// ## iOS Applications
@@ -91,7 +92,9 @@ abstract class ShoppingCartLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('fa')
+    Locale('fa'),
+    Locale('ja'),
+    Locale('it')
   ];
 
   /// No description provided for @shoppingCartPageTitle.
@@ -110,7 +113,7 @@ class _ShoppingCartLocalizationsDelegate extends LocalizationsDelegate<ShoppingC
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en', 'fa'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en', 'fa', 'it', 'ja'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_ShoppingCartLocalizationsDelegate old) => false;
@@ -123,6 +126,8 @@ ShoppingCartLocalizations lookupShoppingCartLocalizations(Locale locale) {
   switch (locale.languageCode) {
     case 'en': return ShoppingCartLocalizationsEn();
     case 'fa': return ShoppingCartLocalizationsFa();
+    case 'it': return ShoppingCartLocalizationsIt();
+    case 'ja': return ShoppingCartLocalizationsJa();
   }
 
   throw FlutterError(

--- a/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_en.dart
+++ b/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_en.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'shopping_cart_localizations.dart';
 
 /// The translations for English (`en`).

--- a/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_fa.dart
+++ b/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_fa.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'shopping_cart_localizations.dart';
 
 /// The translations for Persian (`fa`).
@@ -8,5 +5,5 @@ class ShoppingCartLocalizationsFa extends ShoppingCartLocalizations {
   ShoppingCartLocalizationsFa([String locale = 'fa']) : super(locale);
 
   @override
-  String get shoppingCartPageTitle => 'سبد خرید بیشتر';
+  String get shoppingCartPageTitle => 'سبد خرید';
 }

--- a/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_it.dart
+++ b/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_it.dart
@@ -1,0 +1,9 @@
+import 'shopping_cart_localizations.dart';
+
+/// The translations for Italian (`it`).
+class ShoppingCartLocalizationsIt extends ShoppingCartLocalizations {
+  ShoppingCartLocalizationsIt([String locale = 'it']) : super(locale);
+
+  @override
+  String get shoppingCartPageTitle => 'Carrello';
+}

--- a/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_ja.dart
+++ b/features/shopping_cart/lib/src/l10n/generated/shopping_cart_localizations_ja.dart
@@ -1,0 +1,9 @@
+import 'shopping_cart_localizations.dart';
+
+/// The translations for Japanese (`ja`).
+class ShoppingCartLocalizationsJa extends ShoppingCartLocalizations {
+  ShoppingCartLocalizationsJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get shoppingCartPageTitle => 'ショッピングカート';
+}

--- a/features/shopping_cart/lib/src/l10n/intl_it.arb
+++ b/features/shopping_cart/lib/src/l10n/intl_it.arb
@@ -1,0 +1,4 @@
+{
+    "@@locale": "it",
+    "shoppingCartPageTitle": "Carrello"
+}

--- a/features/shopping_cart/lib/src/l10n/intl_ja.arb
+++ b/features/shopping_cart/lib/src/l10n/intl_ja.arb
@@ -1,0 +1,4 @@
+{
+    "@@locale": "ja",
+    "shoppingCartPageTitle": "ショッピングカート"
+}

--- a/features/shopping_cart/pubspec.lock
+++ b/features/shopping_cart/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,28 +21,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -99,28 +92,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -132,7 +125,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -153,34 +146,27 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/main_app/l10n.yaml
+++ b/main_app/l10n.yaml
@@ -1,4 +1,4 @@
 arb-dir: lib/l10n
 template-arb-file: intl_en.arb
 output-localization-file: app_localizations.dart
-preferred-supported-locales: [en, fa]
+preferred-supported-locales: [en, fa, ja, it]

--- a/main_app/lib/l10n/intl_it.arb
+++ b/main_app/lib/l10n/intl_it.arb
@@ -1,0 +1,4 @@
+{
+    "@@locale": "it",
+    "viewShoppingCartButton": "Visualizza il carrello"
+}

--- a/main_app/lib/l10n/intl_ja.arb
+++ b/main_app/lib/l10n/intl_ja.arb
@@ -1,0 +1,4 @@
+{
+    "@@locale": "ja",
+    "viewShoppingCartButton": "ショッピングカートを見る"
+}

--- a/main_app/pubspec.lock
+++ b/main_app/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -66,21 +66,21 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   shopping_cart:
     dependency: "direct main"
     description:
@@ -93,19 +93,12 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"


### PR DESCRIPTION
@haashem  
Thanks for this really helpful repository and article (https://haashem.medium.com/localizing-flutter-packages-f722d3a814d7) !

I updated the followings, so if it's no problem, merging this is glad to me.
- Update pubspec.lock files
  - I am using Flutter 3.3.1, Dart 2.18.0 and DevTools 2.15.0.
- Add `ja`/`it` localizations.
  - I am Japanese, so `it` translation comes from DeepL result.
- Generate shopping cart localizations
  - These are generated by `flutter gen-l10n` in `./features/shopping_cart` directory.